### PR TITLE
Use XDG's recommendations to store config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ secret=yyyyyyyyyyyyyyyyyy
 
 #### YAML config
 
-Create file named `2fa.yml` in your home directory and add apps in the format
+Create file named `2fa.yml` in `~/.config/rofi-totp` and add apps in the format
 
 ```yml
 apps:

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -16,11 +16,11 @@ pub fn get_list() -> Result<Vec<std::string::String>, String> {
     }
   };
 
-  let config_path = home_dir.join("2fa.yml");
+  let config_path = home_dir.join(".config").join("rofi-totp").join("2fa.yml");
 
   let mut config_file = match File::open(&config_path) {
     Err(_) => {
-      return Err(String::from("Make sure you have .gauth (ini) or 2fa.yml config file in home folder"));
+      return Err(String::from("Make sure you have created the following config file ~/.config/rofi-totp/2fa.yml"));
     }
     Ok(file) => file,
   };


### PR DESCRIPTION
Hey, nice package you've made here, I use it everyday, and I love it!

But the yaml config file in the home directory is not really ideal in my opinion.

Based on [XDG's recommendation](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#:~:text=%24XDG_CONFIG_HOME%20defines%20the%20base%20directory%20relative%20to%20which%20user%2Dspecific%20configuration%20files%20should%20be%20stored.%20If%20%24XDG_CONFIG_HOME%20is%20either%20not%20set%20or%20empty%2C%20a%20default%20equal%20to%20%24HOME/.config%20should%20be%20used.), this file should be placed in the `~/.config/rofi-totp/` directory.

I have started the implementation, but didn't want to change everything as I don't know if you're okay to do the update.

Here are couple of things that should be made:
- [x] Move `~/2fa.yml` to `~/.config/rofi-totp/2fa.yml`
- [ ] Use the `$XDG_CONFIG_HOME` env variable and fallback to `$HOME/.config` to get the location of the config directory
- [ ] Maybe move the `.gauth` too, but as I understood it, you made it compatible with [moul](https://github.com/moul)'s project